### PR TITLE
Number of API calls reduced 

### DIFF
--- a/app/(site)/events/[eventPage]/page.tsx
+++ b/app/(site)/events/[eventPage]/page.tsx
@@ -24,8 +24,8 @@ export default function PageForEvent({params}: Props) {
 
   useEffect(()=>{
     if(!slug) redirect("/");
-    getEventPage(slug).then(data => setEventPage(data))
-  },[slug])
+    if(!eventPage) getEventPage(slug).then(data => setEventPage(data))
+  },[slug, eventPage])
 
   if(!eventPage){
     return <Spinner/>

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -24,14 +24,17 @@ export default function Home() {
   const [events, setEvents] = useState<EventCardType[]>();
 
   useEffect(() => {
-    getEventCards()
+    if(!events){
+      getEventCards()
       .then((data) => {
         setEvents(data);
       })
       .catch((error) => {
         console.error('Error fetching event cards:', error);
       });
-  }, []);
+    }
+    
+  }, [events]);
 
   if(!events){
     return <CenteredSpinner />


### PR DESCRIPTION
This is done with writing the `useEffect` correctly

Main page: 
```javascript
  useEffect(() => {
    if(!events){
      getEventCards()
      .then((data) => {
        setEvents(data);
      })
      .catch((error) => {
        console.error('Error fetching event cards:', error);
      });
    }
    
  }, [events]);

```

Event Page: 
```javascript

useEffect(()=>{
    if(!slug) redirect("/");
    if(!eventPage) getEventPage(slug).then(data => setEventPage(data))
  },[slug, eventPage])

```