### PR TITLE
Error page

### DIFF
--- a/app/(site)/events/[eventPage]/page.tsx
+++ b/app/(site)/events/[eventPage]/page.tsx
@@ -10,6 +10,8 @@ import { useEffect, useState } from "react";
 import { redirect } from 'next/navigation';
 import getDateTimeFormat from "@/utils/date";
 import LoadingPage from "@/components/loadingPage/loadingPage";
+import { error } from "console";
+import { useRouter } from 'next/navigation'
 
 // Props for the event page 
 type Props = {
@@ -20,16 +22,29 @@ export default function PageForEvent({params}: Props) {
   const [eventPage, setEventPage] = useState<EventPageType | null>(null);
 
   const slug = params.eventPage;
+  const router = useRouter()
 
+
+  
   useEffect(()=>{
-    if(!slug) redirect("/");
-    if(!eventPage) getEventPage(slug).then(data => setEventPage(data))
-  },[slug, eventPage])
+    if(!slug) router.push("/");
+    if(!eventPage) {
+      getEventPage(slug)
+      .then(
+        (data) => {
+          if(!data){
+            router.push("/feilside")
+          }
+          setEventPage(data)
+        })
+      .catch(error => console.log("Error catches!", error))}
+  },[slug, eventPage, router])
+  
 
   if(!eventPage){
     return <LoadingPage />
   }
-
+  
   // Information time and date formatted correctly 
   let {dateFormat, timeFormat} = getDateTimeFormat(eventPage.datetime)
   let isOver: Boolean = new Date > new Date(eventPage.datetime);

--- a/app/(site)/feilside/page.tsx
+++ b/app/(site)/feilside/page.tsx
@@ -1,0 +1,32 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export default function ErrorPage() {
+
+    return (
+
+        <main className="min-h-screen bg-gradient-to-tl from-gradient-end via-gradient-mid to-gradient-start backdrop-blur-3xl flex justify-center">
+            <div className="min-w-[80%] h-full p-6  rounded-lg shadow bg-gray-800 border-gray-700 flex flex-col items-center justify-center mt-5 md:mt-20">
+
+                <Image src="/images/404-V3.png" alt="404" width={500} height={500}/>
+                
+                <h5 className="mb-2 text-2xl font-semibold tracking-tight text-white">Ops! Denne siden eksiterer ikke! </h5>
+                
+                <p className="mb-3 font-normal text-gray-400"> 
+                    Linken du har trykket på eksisterer ikkje. Pass på at du har skrevet rikitg i URLen! <br></br>
+                    Om du trur noe er feil skriv en mail til: <br></br>
+                    <Link href="mailto:it@startgjovik.no" className="font-bold text-2xl flex justify-center my-10 hover:underline">it@startgjovik.no</Link>
+                </p>
+                <Link href="/" className="inline-flex items-center text-blue-600 hover:underline">
+                    Tilbake til www.startgjovik.no! 
+                    <svg className="w-5 h-5 ml-2" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z"></path><path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z"></path></svg>
+                </Link>
+
+
+
+            </div>
+
+        </main>
+    )
+
+}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -10,11 +10,15 @@ import Logo from '@/components/UI/logo';
 import EventCardList from '@/components/events/eventCardList';
 import NoEvents from '@/components/UI/noEventsFound';
 import LoadingPage from '@/components/loadingPage/loadingPage';
+import ErrorPage from './feilside/page';
+import { NextResponse } from 'next/server';
+import { useRouter } from 'next/navigation';
 
 
 export default function Home() {
 
   const [events, setEvents] = useState<EventCardType[]>();
+  const router = useRouter();
 
   useEffect(() => {
     if(!events){
@@ -23,11 +27,11 @@ export default function Home() {
         setEvents(data);
       })
       .catch((error) => {
-        console.error('Error fetching event cards:', error);
+        router.push("/feilside")
       });
     }
     
-  }, [events]);
+  }, [events, router]);
 
   if(!events){
     return <LoadingPage />


### PR DESCRIPTION
Error page was created with the same code as before the bug. 

Use `router.push()` for navigating to the error page. 
Here is the style: 

![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/66110094/57a4e095-75a8-49ec-a807-55f32e688ada)
