### PR TITLE
Bug: Links that are not open should not be clickable

### DIFF
--- a/components/JoinList/joinlist.tsx
+++ b/components/JoinList/joinlist.tsx
@@ -24,7 +24,7 @@ export default function JoinList() {
             <div>
                 <a href="mailto:hr@startgjovik.no" className="inline-flex items-center text-xs font-normal text-gray-500 hover:underline dark:text-gray-400">
                     <svg className="w-3 h-3 mr-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7.529 7.988a2.502 2.502 0 0 1 5 .191A2.441 2.441 0 0 1 10 10.582V12m-.01 3.008H10M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                        <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7.529 7.988a2.502 2.502 0 0 1 5 .191A2.441 2.441 0 0 1 10 10.582V12m-.01 3.008H10M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                     </svg>
                     Ønsker du å bli med, men usikker på avdeling? <br/>
                     Send en åpen søknad til HR (hr@startgjovik.no)!

--- a/components/JoinList/joinlistelement.tsx
+++ b/components/JoinList/joinlistelement.tsx
@@ -23,7 +23,7 @@ const getStatusBadge = (status: JoinStatus) =>{
 
 export default function JoinListElement({formUrl, title, status }:Props) {
 
-    const style = status === JoinStatus.OPEN ? " bg-gray-700 hover:bg-gray-600" : "bg-gray-900 cursor-not-allowed"
+    const style = status === JoinStatus.OPEN ? " bg-gray-700 hover:bg-gray-600" : "bg-gray-900 cursor-not-allowed pointer-events-none"
 
     return (
         <li>


### PR DESCRIPTION
### What has changed? ✨

Links for forms that are not marked as **ÅPEN**, should not be clickable 

![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/66110094/34471599-69d9-49cc-8a2a-8ceb263335fc)


### How did you solve/implement it? 🧠

Added the following tailwind CSS to the links that are not clickable 

`cursor-not-allowed pointer-events-none`