### PR TITLE
Sanity: schema for Verv

### DIFF
--- a/backend/schemas/index.ts
+++ b/backend/schemas/index.ts
@@ -1,6 +1,7 @@
 import event from "./event";
+import verv from "./verv";
 
 // All schemas that the admin can modify 
-const schemas = [event];
+const schemas = [event,verv];
 
 export default schemas;

--- a/backend/schemas/verv.ts
+++ b/backend/schemas/verv.ts
@@ -1,0 +1,39 @@
+import { JoinStatus } from "@/components/JoinList/joinlistelement";
+
+const verv = {
+    name: "verv",
+    title: "Verv",
+    type: "document",
+    fields: [
+        {
+            name: "title",
+            title: "Tittel",
+            description: "Tittel til verv. F.eks IT Verv",
+            type: "string",
+            required: true
+        },
+        {
+            name:"url",
+            title: "Url",
+            description: "Link til påmeldingskjema for vervet",
+            type: "url",
+            required: true
+        },
+        {
+            title: "Status",
+            description: "Velg status for opptak til vervet. NB! Kun åpen status vil gi tilgang til påmeldingen",
+            name: "type",
+            type: "string",
+            options: {
+              list: [
+                { title: "Open", value: JoinStatus.OPEN },
+                { title: "Coming Soon", value: JoinStatus.COMING_SOON },
+                { title: "Closed", value: JoinStatus.CLOSED },
+              ],
+            },
+            initialValue: JoinStatus.COMING_SOON
+          }
+    ],
+};
+
+export default verv;


### PR DESCRIPTION
### What has changed? ✨

Created a schema for verv.  This will be part of the solution for making it easy to add a new Verv for the public. 

![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/66110094/a497be45-c7e4-4af6-a3bb-3700b9de3a46)


### How did you solve/implement it? 🧠

See the **verv.ts** in the backend folder.
Used sanity docs to achieve this!