### PR TITLE
fix: bug with value of enum

### DIFF
--- a/backend/schemas/verv.ts
+++ b/backend/schemas/verv.ts
@@ -26,9 +26,9 @@ const verv = {
             type: "string",
             options: {
               list: [
-                { title: "Open", value: JoinStatus.OPEN },
-                { title: "Coming Soon", value: JoinStatus.COMING_SOON },
-                { title: "Closed", value: JoinStatus.CLOSED },
+                { title: "Open", value: JoinStatus.OPEN.toString() },
+                { title: "Coming Soon", value: JoinStatus.COMING_SOON.toString() },
+                { title: "Closed", value: JoinStatus.CLOSED.toString() },
               ],
             },
             initialValue: JoinStatus.COMING_SOON


### PR DESCRIPTION
### What has changed? ✨

Had a small bug, where Sanity Studio expected a string but got a number.

### How did you solve/implement it? 🧠

Solved it by changing and adding toString() to each enum where the string is needed. 