### PR TITLE
all fetched events are shown on the list of possible verv

### DIFF
--- a/backend/sanity-utils.ts
+++ b/backend/sanity-utils.ts
@@ -1,5 +1,6 @@
 import { EventCardType } from "@/types/EventCardType";
 import { EventPageType } from "@/types/EventPageType";
+import { VervType } from "@/types/Verv";
 import { createClient, groq } from "next-sanity";
 
 // Async function that gets all event cards available 
@@ -44,5 +45,24 @@ export async function getEventPage(slug: string): Promise<EventPageType> {
         datetime
       }`,
       { slug }
+    )
+}
+
+// Async function that gets all vervtypes from the backend
+export async function getVervs(): Promise<VervType[]>{
+    const client = createClient({
+        projectId: "a42ubgcg",
+        dataset: "production",
+        apiVersion: "2023-07-06",
+        useCdn: false 
+    });
+
+    return client.fetch(
+        groq`*[_type == "verv"]{
+            _id,
+            title,
+            url,
+            type
+        }`
     )
 }

--- a/components/JoinList/joinlist.tsx
+++ b/components/JoinList/joinlist.tsx
@@ -1,6 +1,34 @@
+"use client";
+
+import { useRouter } from "next/navigation";
 import JoinListElement, { JoinStatus } from "./joinlistelement";
+import { getVervs } from "@/backend/sanity-utils";
+import { useState, useEffect } from "react";
+import LoadingPage from "../loadingPage/loadingPage";
+import { VervType } from "@/types/Verv";
 
 export default function JoinList() {
+
+    const [vervs, setVervs] = useState<VervType[]>();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (!vervs) {
+            getVervs()
+                .then((data) => {
+                    setVervs(data);
+                })
+                .catch((error) => {
+                    router.push("/feilside")
+                });
+        }
+
+    }, [vervs, router]);
+
+    if (!vervs) {
+        return <LoadingPage />
+    }
+
     return (
 
         <div className="w-full max-w-sm p-4 border  rounded-lg shadow sm:p-6 bg-gray-800 border-gray-700">
@@ -9,26 +37,32 @@ export default function JoinList() {
             </h5>
 
             <p className="text-sm font-normal text-gray-400">
-                Våre avdelinger trenger engasjerte studenter til å forme Start Gjøvik. 
-                Her er en liste med alle avdelinger som er åpne for nye studenter! <br/> <br/>
+                Våre avdelinger trenger engasjerte studenter til å forme Start Gjøvik.
+                Her er en liste med alle avdelinger som er åpne for nye studenter! <br /> <br />
 
-                Klikk på linkene under for å søke! ✍ 
+                Klikk på linkene under for å søke! ✍
             </p>
 
             <ul className="my-4 space-y-3">
-                <JoinListElement formUrl="https://forms.gle/7yxEwP1HqtarFaQi6" status={JoinStatus.OPEN} title="IT Verv"/>
-                <JoinListElement formUrl="#" status={JoinStatus.COMING_SOON} title="Event Verv" />
-                <JoinListElement formUrl="#" status={JoinStatus.COMING_SOON} title="PR Verv" />
-                
+
+                {vervs && vervs.length > 0 ? (
+                    vervs.map((verv) => (
+                        <JoinListElement key={verv._id} formUrl={verv.url} status={verv.type as number} title={verv.title} />
+                    ))
+                ) : (
+                    <h4>Ingen Verv Ute!</h4>
+                )}
+
+
             </ul>
             <div>
                 <a href="mailto:hr@startgjovik.no" className="inline-flex items-center text-xs font-normal hover:underline text-gray-400">
                     <svg className="w-3 h-3 mr-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                         <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7.529 7.988a2.502 2.502 0 0 1 5 .191A2.441 2.441 0 0 1 10 10.582V12m-.01 3.008H10M19 10a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                     </svg>
-                    Ønsker du å bli med, men usikker på avdeling? <br/>
+                    Ønsker du å bli med, men usikker på avdeling? <br />
                     Send en åpen søknad til HR (hr@startgjovik.no)!
-                
+
                 </a>
             </div>
         </div>

--- a/components/JoinList/joinlistelement.tsx
+++ b/components/JoinList/joinlistelement.tsx
@@ -1,7 +1,7 @@
 interface Props{
     title: string,
     formUrl: string,
-    status: JoinStatus
+    status: number
 
 }
 
@@ -21,15 +21,24 @@ const getStatusBadge = (status: JoinStatus) =>{
 }
 
 
+// Transforming a status code into the correct type 
+const statusMap : Record<string, JoinStatus>= {
+    "0" : JoinStatus.OPEN,
+    "1" : JoinStatus.COMING_SOON,
+    "2" : JoinStatus.CLOSED
+}
+
+
 export default function JoinListElement({formUrl, title, status }:Props) {
 
-    const style = status === JoinStatus.OPEN ? " bg-gray-700 hover:bg-gray-600" : "bg-gray-900 cursor-not-allowed pointer-events-none"
+    let statusType: JoinStatus = statusMap[status];
+    const style = statusType === JoinStatus.OPEN ? " bg-gray-700 hover:bg-gray-600" : "bg-gray-900 cursor-not-allowed pointer-events-none"
 
     return (
         <li>
             <a href={formUrl} target="_blank" className={"flex items-center p-3 text-white rounded-lg text-base font-bold hover:shadow "+ style}>
                 <span className="flex-1 ml-3 whitespace-nowrap">{title}</span>
-                {getStatusBadge(status)}
+                {getStatusBadge(statusType)}
             </a>
         </li>
     )

--- a/types/Verv.ts
+++ b/types/Verv.ts
@@ -1,0 +1,8 @@
+import { JoinStatus } from "@/components/JoinList/joinlistelement"
+
+export type VervType = {
+    _id: string,
+    title: string,
+    url: string,
+    type: JoinStatus
+}


### PR DESCRIPTION
### What has changed? ✨

Implemented the frontend code for using the fetch method to get the vervs and display them on the main page. 

### How did you solve/implement it? 🧠

Created the following fetch method:

```typescript

// Async function that gets all vervtypes from the backend
export async function getVervs(): Promise<VervType[]>{
    const client = createClient({
        projectId: "a42ubgcg",
        dataset: "production",
        apiVersion: "2023-07-06",
        useCdn: false 
    });

    return client.fetch(
        groq`*[_type == "verv"]{
            _id,
            title,
            url,
            type
        }`
    )
}

```


Then used them in the frontend code: 

```typescript
// Transforming a status code into the correct type 
const statusMap : Record<string, JoinStatus>= {
    "0" : JoinStatus.OPEN,
    "1" : JoinStatus.COMING_SOON,
    "2" : JoinStatus.CLOSED
}


export default function JoinListElement({formUrl, title, status }:Props) {

    let statusType: JoinStatus = statusMap[status];
    const style = statusType === JoinStatus.OPEN ? " bg-gray-700 hover:bg-gray-600" : "bg-gray-900 cursor-not-allowed pointer-events-none"

    return (
        <li>
            <a href={formUrl} target="_blank" className={"flex items-center p-3 text-white rounded-lg text-base font-bold hover:shadow "+ style}>
                <span className="flex-1 ml-3 whitespace-nowrap">{title}</span>
                {getStatusBadge(statusType)}
            </a>
        </li>
    )
}

```