### PR TITLE
refacotr: Adds .prettierc config file for default formatting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+    "extends": "next/core-web-vitals"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-    "extends": "next/core-web-vitals"
+    "extends": ["next/core-web-vitals", "prettier"]
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,23 @@
+{
+    "arrowParens": "always",
+    "bracketSpacing": true,
+    "endOfLine": "lf",
+    "htmlWhitespaceSensitivity": "css",
+    "insertPragma": false,
+    "singleAttributePerLine": false,
+    "bracketSameLine": false,
+    "jsxBracketSameLine": false,
+    "jsxSingleQuote": false,
+    "printWidth": 120,
+    "proseWrap": "preserve",
+    "quoteProps": "as-needed",
+    "requirePragma": false,
+    "semi": true,
+    "singleQuote": false,
+    "tabWidth": 4,
+    "trailingComma": "es5",
+    "useTabs": false,
+    "embeddedLanguageFormatting": "auto",
+    "vueIndentScriptAndStyle": false,
+    "parser": "json"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "sanity": "^3.17.0",
         "tailwindcss": "3.3.2",
         "typescript": "5.2.2"
+      },
+      "devDependencies": {
+        "eslint-config-prettier": "^9.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4184,6 +4187,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "sanity": "^3.17.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.2.2"
+  },
+  "devDependencies": {
+    "eslint-config-prettier": "^9.0.0"
   }
 }


### PR DESCRIPTION
### What has changed? ✨
New root file `.prettierc.json` that has a set up code-formatting 'rules'.

### How did you solve/implement it? 🧠

Added a new config file based on my local options. 