### PR TITLE
fix(urgent?): aligns eventcards section properly

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -57,12 +57,9 @@ export default function Home() {
         </div>
 
                 {/** Listing all events if there are any  */}
-                <div className='grid  md:grid-cols-[repeat(auto-fit,minmax(500px,1fr))] gap-4 justify-center px-5 sm:px-24 md:px-40 mt-10 md:mt-20 transition-all ease-out duration-300 '>
+                <div className='lg:grid lg:grid-cols-[repeat(auto-fit,minmax(500px,1fr))] flex flex-col justify-center items-center w-screen gap-4 px-5 sm:px-24 md:px-40 mt-10 md:mt-20 transition-all ease-out duration-300 '>
                     {events && events.length > 0 ? (
-                        <>
                             <EventCardList events={events} />
-                            <EventCardList events={events} />
-                        </>
                     ) : (
                         <NoEvents />
                     )}

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -38,35 +38,31 @@ export default function Home() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-gradient-to-tl from-gradient-end via-gradient-mid to-gradient-start">
-      <main className="min-h-screen">
-        <Logo />
+      <div className='flex flex-col min-h-screen bg-gradient-to-tl from-gradient-end via-gradient-mid to-gradient-start'>
+          <main className='min-h-screen'>
+              <Logo />
 
-        {/** Paragraph for introduction */}
-        <HeaderJumbotron />
+              {/** Paragraph for introduction */}
+              <HeaderJumbotron />
 
-        {/**Cards with info about Start Gjøvik */}
-        <Hero />
+              {/**Cards with info about Start Gjøvik */}
+              <Hero />
 
-        {/** Line Breaker */}
-        <hr className="w-4/5 h-1 mx-auto my-20 bg-gray-100 border-0 rounded md:my-10" />
+              {/** Line Breaker */}
+              <hr className='w-4/5 h-1 mx-auto my-20 bg-gray-100 border-0 rounded md:my-10' />
 
-        {/**List of events */}
-        <div className="flex justify-center items-center">
-          <h3 className="font-sans font-bold text-4xl px-10 sm:text-5xl">📅 Kommende Arrangementer</h3>
-        </div>
+              {/**List of events */}
+              <div className='flex justify-center items-center'>
+                  <h3 className='font-sans font-bold text-4xl px-10 sm:text-5xl'>📅 Kommende Arrangementer</h3>
+              </div>
 
-                {/** Listing all events if there are any  */}
-                <div className='lg:grid lg:grid-cols-[repeat(auto-fit,minmax(500px,1fr))] flex flex-col justify-center items-center w-screen gap-4 px-5 sm:px-24 md:px-40 mt-10 md:mt-20 transition-all ease-out duration-300 '>
-                    {events && events.length > 0 ? (
-                            <EventCardList events={events} />
-                    ) : (
-                        <NoEvents />
-                    )}
-                </div>
-            </main>
+              {/** Listing all events if there are any  */}
+              <div className='flex flex-col md:grid md:grid-cols-2 xl:grid-cols-[repeat(auto-fit,minmax(500px,1fr))] justify-center items-center w-screen gap-4 px-5 sm:px-24 md:px-32 mt-10 md:mt-20 transition-all ease-out duration-300 '>
+                  {events && events.length > 0 ? <EventCardList events={events} /> : <NoEvents />}
+              </div>
+          </main>
 
-      <Footer />
-    </div>
-  )
+          <Footer />
+      </div>
+  );
 }

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -56,11 +56,18 @@ export default function Home() {
           <h3 className="font-sans font-bold text-4xl px-10 sm:text-5xl">📅 Kommende Arrangementer</h3>
         </div>
 
-              {/** Listing all events if there are any  */}
-              <div className='grid justify-center grid-cols-[repeat(auto-fit,minmax(400px,1fr))]  px-10 sm:px-24 md:px-40 mt-20 transition-all ease-out duration-300 '>
-                  {events && events.length > 0 ? <EventCardList events={events} /> : <NoEvents />}
-              </div>
-          </main>
+                {/** Listing all events if there are any  */}
+                <div className='grid  md:grid-cols-[repeat(auto-fit,minmax(500px,1fr))] gap-4 justify-center px-5 sm:px-24 md:px-40 mt-10 md:mt-20 transition-all ease-out duration-300 '>
+                    {events && events.length > 0 ? (
+                        <>
+                            <EventCardList events={events} />
+                            <EventCardList events={events} />
+                        </>
+                    ) : (
+                        <NoEvents />
+                    )}
+                </div>
+            </main>
 
       <Footer />
     </div>

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -56,12 +56,11 @@ export default function Home() {
           <h3 className="font-sans font-bold text-4xl px-10 sm:text-5xl">📅 Kommende Arrangementer</h3>
         </div>
 
-        {/** Listing all events if there are any  */}
-        <div className="flex flex-wrap justify-center items-center px-5 mt-20 gap-5 md:flex-row">
-        { events && events.length > 0 ? <EventCardList events={events} /> : <NoEvents/>}
-        </div>
-        
-      </main>
+              {/** Listing all events if there are any  */}
+              <div className='grid justify-center grid-cols-[repeat(auto-fit,minmax(400px,1fr))]  px-10 sm:px-24 md:px-40 mt-20 transition-all ease-out duration-300 '>
+                  {events && events.length > 0 ? <EventCardList events={events} /> : <NoEvents />}
+              </div>
+          </main>
 
       <Footer />
     </div>

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -14,12 +14,12 @@ interface EventProps{
 export default function EventCard({date, title, imageUrl, time, description, slug}: EventProps): JSX.Element {
     
     return (
-        <div className='max-w-sm w-full lg:max-w-full lg:flex border rounded-lg shadow border-gray-700 bg-gray-800 hover:bg-gray-700'>
+        <div className='max-w-sm w-full lg:max-w-full lg:flex lg:justify-stretch lg:items-stretch h-full rounded-lg shadow  bg-gray-800 hover:bg-gray-700'>
             <div
                 className='h-48 lg:h-auto lg:w-48 flex-none bg-cover rounded-t lg:rounded-t-none lg:rounded-l text-center overflow-hidden md:rounded-none md:rounded-l-lg'
                 style={{ backgroundImage: `url(${imageUrl})` }}
                 title='Event image'></div>
-            <div className='flex flex-col border-r border-b border-l lg:border-l-0 lg:border-t lg:border-gray-400  rounded-b lg:rounded-b-none lg:rounded-r p-4 justify-between leading-normal '>
+            <div className='flex flex-col rounded-b lg:rounded-b-none lg:rounded-r p-4 justify-between leading-normal '>
                 <div className='mb-4'>
                     <div className='mb-2 text-xl font-bold tracking-tight text-white'>{title}</div>
                     <p className='mb-3 font-normal text-gray-400'>{description}</p>

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -18,7 +18,7 @@ export default function EventCard({date, title, imageUrl, time, description, slu
     return (
         <div className='flex flex-col items-stretch text-start m-[1em]  justify-stretch min-w-[302px] border rounded-lg shadow md:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700'>
             <Image
-                className='transition-all ease-out duration-300 object-fit rounded-t-lg md:w-48 md:rounded-none md:rounded-l-lg'
+                className='transition-all ease-out duration-300 rounded-t-lg md:w-36 lg:w-44 xl:w-64 md:rounded-none md:rounded-l-lg'
                 src={imageUrl}
                 alt='project card'
                 width={400}

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -1,5 +1,3 @@
-import event from "@/backend/schemas/event";
-import Image from "next/image";
 import Link from "next/link";
 
 // Interface for the event card
@@ -16,25 +14,32 @@ interface EventProps{
 export default function EventCard({date, title, imageUrl, time, description, slug}: EventProps): JSX.Element {
     
     return (
-        <div className='flex flex-col items-stretch text-start m-[1em] justify-stretch min-w-[302px] border rounded-lg shadow lg:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700'>
-            <Image
-                className='transition-all ease-out duration-300 rounded-t-lg md:w-full lg:w-56 xl:w-72 md:rounded-none md:rounded-l-lg'
-                src={imageUrl}
-                alt='project card'
-                width={400}
-                height={400}
-            />
-            <div className='flex flex-col justify-between p-4 leading-normal'>
-                <h5 className='mb-2 text-2xl font-bold tracking-tight text-white'>{title}</h5>
-                <p className='mb-3 font-normal text-gray-400 flex flex-1'>{description}</p>
-                <h4> 📅 {date}</h4>
-                <h4>🕕 {time}</h4>
-                <Link href={`/arrangementer/${slug}`} className="inline-flex items-center px-3 py-2 mt-2 text-sm font-medium text-center text-white  rounded-lg focus:ring-4 focus:outline-none  bg-blue-600 hover:bg-blue-700 focus:ring-blue-800">
-                    Les meir
-                    <svg aria-hidden="true" className="w-4 h-4 ml-2 -mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fillRule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clipRule="evenodd"></path></svg>
-                </Link>
+        <div className='max-w-sm w-full lg:max-w-full lg:flex border rounded-lg shadow border-gray-700 bg-gray-800 hover:bg-gray-700'>
+            <div
+                className='h-48 lg:h-auto lg:w-48 flex-none bg-cover rounded-t lg:rounded-t-none lg:rounded-l text-center overflow-hidden md:rounded-none md:rounded-l-lg'
+                style={{ backgroundImage: `url(${imageUrl})` }}
+                title='Event image'></div>
+            <div className='flex flex-col border-r border-b border-l lg:border-l-0 lg:border-t lg:border-gray-400  rounded-b lg:rounded-b-none lg:rounded-r p-4 justify-between leading-normal '>
+                <div className='mb-4'>
+                    <div className='mb-2 text-xl font-bold tracking-tight text-white'>{title}</div>
+                    <p className='mb-3 font-normal text-gray-400'>{description}</p>
+                </div>
+                <div className='flex items-start flex-col'>
+                    <h4> 📅 {date}</h4>
+                    <h4>🕕 {time}</h4>
+                    <Link
+                        href={`/arrangementer/${slug}`}
+                        className='inline-flex items-center w-full px-3 py-2 mt-2 text-sm font-medium text-center text-white  rounded-lg focus:ring-4 focus:outline-none  bg-blue-600 hover:bg-blue-700 focus:ring-blue-800'>
+                        Les meir{' '}
+                        <svg aria-hidden='true' className='w-4 h-4 ml-2 -mr-1' fill='currentColor' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'>
+                            <path
+                                fillRule='evenodd'
+                                d='M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z'
+                                clipRule='evenodd'></path>
+                        </svg>{' '}
+                    </Link>
+                </div>
             </div>
-
-        </div>   
+        </div>
     );
 }

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -16,21 +16,17 @@ interface EventProps{
 export default function EventCard({date, title, imageUrl, time, description, slug}: EventProps): JSX.Element {
     
     return (
-        <div className="flex flex-col items-center border rounded-lg shadow md:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700">
+        <div className='flex flex-col items-stretch text-start m-[1em]  justify-stretch min-w-[302px] border rounded-lg shadow md:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700'>
             <Image
-                className="object-cover w-full rounded-t-lg h-96 md:h-48 md:w-48 md:rounded-none md:rounded-l-lg"
+                className='transition-all ease-out duration-300 object-fit rounded-t-lg md:w-48 md:rounded-none md:rounded-l-lg'
                 src={imageUrl}
-                alt="project card"
+                alt='project card'
                 width={400}
                 height={400}
             />
-            <div className="flex flex-col justify-between p-4 leading-normal"> 
-                <h5 className="mb-2 text-2xl font-bold tracking-tight text-white">
-                    {title}
-                </h5>
-                <p className="mb-3 font-normal text-gray-400">
-                    {description}
-                </p>
+            <div className='flex flex-col justify-between p-4 leading-normal'>
+                <h5 className='mb-2 text-2xl font-bold tracking-tight text-white'>{title}</h5>
+                <p className='mb-3 font-normal text-gray-400 flex flex-1'>{description}</p>
                 <h4> 📅 {date}</h4>
                 <h4>🕕 {time}</h4>
                 <Link href={`/arrangementer/${slug}`} className="inline-flex items-center px-3 py-2 mt-2 text-sm font-medium text-center text-white  rounded-lg focus:ring-4 focus:outline-none  bg-blue-600 hover:bg-blue-700 focus:ring-blue-800">

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -16,9 +16,9 @@ interface EventProps{
 export default function EventCard({date, title, imageUrl, time, description, slug}: EventProps): JSX.Element {
     
     return (
-        <div className='flex flex-col items-stretch text-start m-[1em]  justify-stretch min-w-[302px] border rounded-lg shadow md:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700'>
+        <div className='flex flex-col items-stretch text-start m-[1em] justify-stretch min-w-[302px] border rounded-lg shadow lg:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700'>
             <Image
-                className='transition-all ease-out duration-300 rounded-t-lg md:w-36 lg:w-44 xl:w-64 md:rounded-none md:rounded-l-lg'
+                className='transition-all ease-out duration-300 rounded-t-lg md:w-full lg:w-56 xl:w-72 md:rounded-none md:rounded-l-lg'
                 src={imageUrl}
                 alt='project card'
                 width={400}


### PR DESCRIPTION
### What has changed? ✨
The section for event cards has been improved: See the differences below:
*Before:*
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/116307580/752e9522-36ae-4302-aabd-1b91ea01e4fa)
*After:*
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/116307580/ef32f9ba-9d5f-4396-ae9e-7f75c51e5c2a)

### How did you solve/implement it? 🧠
For the event cards-container now uses grid instead of flex. This ensures that every card matches the neighbor's height regardless of the content.  Furthermore, the image for each card has been set to `object-fit` (previously `object-cover`) so that the whole picture is represented (which may contain some important info). Lastly, added smoothing transitions for both the image and the container.  
*Also been tested for mobile-use and seems to be behaving fine.*