### PR TITLE
revesed order of elements in events to sort by newest event

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -24,6 +24,7 @@ export default function Home() {
     if(!events){
       getEventCards()
       .then((data) => {
+        data.reverse();
         setEvents(data);
       })
       .catch((error) => {


### PR DESCRIPTION
### What has changed? ✨
I sorted the events at the bottom of the main page. 
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/99ef6fe6-92fc-43e7-b31e-eb7a3c29f07a)

### How did you solve/implement it? 🧠
I saw in the backend that the newer events gets placed behind in an array. Which means that when you fetch the array from sanity you will get the the data in order from oldest to newst. To sort this I simpily revesed the array before storing and rendering it. 