### PR TITLE
fix: event date format

### DIFF
--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -1,6 +1,8 @@
 import event from "@/backend/schemas/event";
 import Image from "next/image";
 import Link from "next/link";
+import { split } from "lodash";
+import getEnglishMonth from "@/utils/englishMonth";
 
 // Define the props interface for the EventCard component
 interface EventProps {
@@ -22,17 +24,12 @@ const EventCard: React.FC<EventProps> = ({
   slug,
 }: EventProps) => {
   
-  // Calculate the event date and time as a JavaScript Date object
-  const eventDateTime = date && time ? new Date(`${date}T${time}`) : null;
-  console.log("eventDateTime:", eventDateTime);
-  // Get the current date and time as a JavaScript Date object
-  const currentDateTime = new Date();
-  console.log("currentDateTime:", currentDateTime);
+  const [monthNum, monthNorwegian] = date ? split(date, ' ') : [null, null];
 
-  // Check if the event has finished by comparing eventDateTime and currentDateTime
-  const eventFinished = eventDateTime && eventDateTime < currentDateTime;
-  console.log("eventFinished:", eventFinished);
-  // Render the EventCard component
+  const eventDateTime = date && time ? new Date(`${monthNum} ${getEnglishMonth(monthNorwegian)} ${new Date().getFullYear()} ${time}`) : null;
+  const currentDateTime = new Date();
+const eventFinished = eventDateTime && eventDateTime < currentDateTime;
+    
   return (
     <div className="flex flex-col items-center border rounded-lg shadow md:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700">
       <Image
@@ -87,5 +84,4 @@ const EventCard: React.FC<EventProps> = ({
   );
 };
 
-// Export the EventCard component as the default export
 export default EventCard;

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -24,11 +24,11 @@ const EventCard: React.FC<EventProps> = ({
   slug,
 }: EventProps) => {
   
-  const [monthNum, monthNorwegian] = date ? split(date, ' ') : [null, null];
+  const [dayNum, monthNorwegian] = date ? split(date, ' ') : [null, null];
 
-  const eventDateTime = date && time ? new Date(`${monthNum} ${getEnglishMonth(monthNorwegian)} ${new Date().getFullYear()} ${time}`) : null;
+  const eventDateTime = date && time ? new Date(`${dayNum} ${(getEnglishMonth(monthNorwegian as any))} ${new Date().getFullYear()} ${time}`) : null;
   const currentDateTime = new Date();
-const eventFinished = eventDateTime && eventDateTime < currentDateTime;
+  const eventFinished = eventDateTime && eventDateTime < currentDateTime;
     
   return (
     <div className="flex flex-col items-center border rounded-lg shadow md:flex-row md:max-w-xl max-w-md border-gray-700 bg-gray-800 hover:bg-gray-700">

--- a/utils/englishMonth.ts
+++ b/utils/englishMonth.ts
@@ -1,0 +1,18 @@
+const monthMap = {
+    januar: 'January',
+    februar: 'February',
+    mars: 'March',
+    april: 'April',
+    mai: 'May',
+    juni: 'June',
+    juli: 'July',
+    august: 'August',
+    september: 'September',
+    oktober: 'October',
+    november: 'November',
+    desember: 'December',
+};
+
+export default function getEnglishMonth(month: keyof typeof monthMap): string {
+  return monthMap[month];
+}


### PR DESCRIPTION
### What has changed? ✨
Some events with a month name different from the English month name (e.g. October) will return "invalid date", due to `new Date()` constructor only accepting English month names. The event's month name (Norwegian) is now converted to English.

### How did you solve/implement it? 🧠
Made a new function (and a new file) `getEnglishMonth` that returns the English-equivalent month name.  
Also modified some of the code for the `EventCard` component so that it splits `date` prop into `dayNum` (day number e.g. 26 ) and `monthNorwegian`. 