### PR TITLE
Front page animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,7 +52,7 @@ body {
   content: '';
   display: block;
   width: 100%;
-  height: 0.125em;
+  height: 0.1em;
   background-color: white;
   position: absolute; 
   top: 0;

--- a/components/heroSection/hero.tsx
+++ b/components/heroSection/hero.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, Variants } from 'framer-motion';
 import { Item } from '@/types/Item';
 import Image from 'next/image';
 
@@ -46,20 +46,40 @@ export default function Hero() {
         setSelectedId(selectedId === itemId ? null : itemId);
     };
 
+    const fadeInAnimation: Variants = {
+        initial: {
+            opacity: 0,
+            x: -250
+        },
+        animate: (index: number) => ({
+            opacity: 1,
+            x: 0,
+            transition: {
+                delay: 0.2 * index,
+            }
+        }),
+    }
+
     return (
         <div className="flex flex-wrap justify-center">
-            {items.map(item => (
+            {items.map((item, index) => (
                 <motion.div
                     key={item.id}
                     layoutId={`item-${item.id}`}
                     onClick={() => handleCardClick(item.id)}
-                    className={`flex flex-col items-center justify-center p-6 m-4 rounded-lg cursor-pointer shadow-lg w-72 h-72 ${item.color}`}
+                    className={` z-auto flex flex-col items-center justify-center p-6 m-4 rounded-lg cursor-pointer shadow-lg w-72 h-72 ${item.color}`}
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
-                    initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: 0.3 }}
+                    initial="initial"
+                    variants={fadeInAnimation}
+                    whileInView="animate"
+                    viewport={{
+                        once: true,
+                    }}
+                    custom={index}
                 >
                     <motion.h5 className="text-gray-100 text-xl">{item.subtitle}</motion.h5>
                     <motion.h2 className="text-white text-3xl font-bold mt-2">{item.title}</motion.h2>

--- a/components/navbar/page.tsx
+++ b/components/navbar/page.tsx
@@ -13,7 +13,7 @@ export const scrollIntoTheView = (id: string) => {
     if (!element) return;
 
     element.scrollIntoView({
-        behavior: "auto",
+        behavior: "smooth",
     });
 };
 
@@ -48,11 +48,11 @@ export default function Navbar() {
     const fadeInAnimation: Variants = {
         initial: {
             opacity: 0,
-            x: -50
+            y: -20
         },
         animate: (index: number) => ({
             opacity: 1,
-            x: 0,
+            y: 0,
             transition: {
                 delay: 0.05 * index,
             }
@@ -68,15 +68,14 @@ export default function Navbar() {
 
     return (
         <div className="bg-darkblue">
-            <nav className="flex items-center justify-between py-4 phone:pb-0 phone:pt-1 phone:pl-3 pl-5 text-white text-2xl font-semibold">
-                <div className='tablet:hidden desktop:hidden'>
+            <nav className="flex items-center justify-between py-4 sm:pb-0 sm:pt-1 sm:pl-3 pl-5 text-white text-2xl font-semibold">
+                <div className='sm:block md:hidden lg:hidden xl:hidden 2xl:hidden'>
                     <DropDownMenu menuItems={burgerMenyuItems} title="" menuIcon={burgerMenuIcon} textSize='text-2xl' />
                 </div>
                 <ul className="flex space-x-7 -space-y-0 tracking-tight leading-none">
 
                     {homePageMenuItems.map((item, index) => (
-
-                        <motion.li key={index} className='phone:hidden'
+                        <motion.li key={index} className='sm:hidden md:block lg:block xl:block 2xl:block'
                             initial="initial"
                             variants={fadeInAnimation}
                             whileInView="animate"
@@ -84,12 +83,13 @@ export default function Navbar() {
                                 once: true,
                             }}
                             custom={index}
+                            whileHover={{ scale: 1.1 }}
                         >
                             <Link key={index} href={item.path} className={`link ${pathname === item.path ? 'active-link' : ''} `}>{item.name}</Link>
                         </motion.li>
 
                     ))}
-                    <motion.li className='phone:hidden'
+                    <motion.li className='sm:hidden md:block lg:block xl:block 2xl:block'
                         initial="initial"
                         variants={fadeInAnimation}
                         whileInView="animate"
@@ -97,6 +97,7 @@ export default function Navbar() {
                             once: true,
                         }}
                         custom={homePageMenuItems.length + 1}
+                        whileHover={{ scale: 1.1 }}
                     >
                         <DropDownMenu menuItems={eventsMenuItems} title="Arrangementer" menuIcon={defualtMenuIcon} textSize='text-lg' />
                     </motion.li>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,9 +7,15 @@ module.exports = {
   ],
   theme: {
     screens: {
-      'phone': {'min': '20px', 'max': '767px'},
-      'tablet': {'min': '768px', 'max': '1023px'},
-      'desktop': {'min': '1024px'},
+      'sm': {'max': '767px'},
+
+      'md': {'min': '768px', 'max': '1023px'},
+
+      'lg': {'min': '1024px', 'max': '1279px'},
+
+      'xl': {'min': '1280px', 'max': '1535px'},
+
+      '2xl': {'min': '1536px'},
     },
     extend: {
       colors: {


### PR DESCRIPTION
### What has changed? ✨

Removed custom screen sizes, and added Tailwind CSS standard sizes. However, made small (sm) size not have a lower boundary so that small phone sizes can view the navbar correctly.

Added animation to item cards on the front page. Just to try it out, and as an example on how we can add small animations to the site, does not need to be added to dev branch. 

Made some small changes to the navigation bar animation. 

### How did you solve/implement it? 🧠

Used Framer-motion for animations. 