### PR TITLE
chore: remove appDir config as it's no longer needed

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,14 +3,11 @@ const nextConfig = {
     images: {
         remotePatterns: [
             {
-                protocol: "https",
-                hostname: "cdn.sanity.io",
-                port: "",
+                protocol: 'https',
+                hostname: 'cdn.sanity.io',
+                port: '',
             },
         ],
-    },
-    experimental: {
-        appDir: true,
     },
 };
 


### PR DESCRIPTION
### What has changed? ✨

The `appDir` configuration has been removed as it's no longer needed 
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/116307580/582cecd2-8f12-4a54-9709-7fae512fb9a7)

### How did you solve/implement it? 🧠
Removed from `nex.config.js`-file. 