### PR TITLE
fix: dark-mode removed

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,17 +3,9 @@
 @tailwind utilities;
 
 :root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
     --foreground-rgb: 255, 255, 255;
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
-  }
 }
 
 body {

--- a/components/events/eventCard.tsx
+++ b/components/events/eventCard.tsx
@@ -32,7 +32,7 @@ const EventCard: React.FC<EventProps> = ({ date, title, imageUrl, time, descript
                 </div>
                 <div>
                     {eventFinished ? (
-                        <p className='bg-red-100 text-red-800 text-sm font-medium mr-2 px-3 py-2 rounded-lg dark:bg-red-900 dark:text-red-200 inline'>
+                        <p className='bg-red-100 text-red-800 text-sm font-medium mr-2 px-3 py-2 rounded-lg inline'>
                             ⌛️ Arrangementet er over!
                         </p>
                     ) : (


### PR DESCRIPTION
### What has changed? ✨
(for instance for-bedrifer page)
*before*
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/116307580/71996924-3c34-4759-9d7d-e9e4ed5097d5)
*after*
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/116307580/9224b089-2fe2-4fe5-ab70-8afa8b704f75)
### How did you solve/implement it? 🧠
Removed some css-props. 

```css
@media (prefers-color-scheme: dark) {
  :root {
    --foreground-rgb: 255, 255, 255;
    --background-start-rgb: 0, 0, 0;
    --background-end-rgb: 0, 0, 0;
  }
}
```