### PR TITLE
Front page prop

### DIFF
--- a/app/(site)/for-bedrifter/page.tsx
+++ b/app/(site)/for-bedrifter/page.tsx
@@ -7,6 +7,7 @@ import { InboxIcon, MapIcon, PhoneIcon } from '@heroicons/react/20/solid';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Button from '@/components/Button/button';
+import Frontprop from '@/components/frontPage/frontProp';
 
 const Map = dynamic(() => import('@/components/map/map'), { ssr: false, loading: () => <Spinner /> });
 export default function ForCompany() {

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -44,7 +44,7 @@ export default function Home() {
             {/** Header */}
             <Header />
             <main className='min-h-screen'>
-                <FrontPage path="/images/start_casebreaker.png"   />
+                <FrontPage/>
                 {/**List of events */}
                 <EventSection events={events}></EventSection>
 

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -44,7 +44,7 @@ export default function Home() {
             {/** Header */}
             <Header />
             <main className='min-h-screen'>
-                <FrontPage />
+                <FrontPage path="/images/start_casebreaker.png"   />
                 {/**List of events */}
                 <EventSection events={events}></EventSection>
 

--- a/components/Button/button.tsx
+++ b/components/Button/button.tsx
@@ -13,8 +13,8 @@ export default function Button({ text, link, adaptiv }: ButtonProps) {
                 className={`ring-2 ring-[#B2C51F] text-white hover:text-[#B2C51F] bg-[#B2C51F] 
                             hover:bg-transparent hover:ease-out hover:duration-300
                             active:ring-black active:text-black active:duration-0 
-                            px-[27px] py-[8px] rounded-full font-semibold gap-[10px] h-[62px]
-                            text-xl mt-4 mb-4
+                            px-[27px] py-[8px] rounded-full font-semibold gap-[10px] lg:h-[62px]
+                            sm:h-[40px] text-xl mt-4 mb-4
                             ${adaptiv ? 'w-full ' : 'w-auto'}`}>
                 {text}
             </button>

--- a/components/frontPage/frontPage.tsx
+++ b/components/frontPage/frontPage.tsx
@@ -2,41 +2,22 @@ import Logo from '@/components/UI/logo';
 import Button from '@/components/Button/button';
 import Frontprop from './frontProp';
 
-interface FrontPageProps {
-    path: string;
-    alt?: string;
-}
-
-export default function FrontPage( {path, alt} : FrontPageProps) {
+export default function FrontPage() {
     return (
         <div className='relative'>
-            <Frontprop path={path} title='VELKOMEN TIL' alt={alt} logo={true} />
+            <Frontprop path="/images/start_casebreaker.png" title='VELKOMEN TIL' logo={true} color='#132D4E'/>
             <div
                 className='w-full absolute bottom-0'
                 style={{
                     height: '35%',
                 }}>
-                <div
-                    className='bg-[#132D4E] text-center w-full absolute overflow-hidden opacity-50'
-                    style={{
-                        height: '100%',
-                        clipPath: 'ellipse(70% 100% at 50% 100%)',
-                    }}></div>
-
-                <div
-                    className='bg-[#132D4E] text-center w-full flex flex-col justify-center items-center relative overflow-hidden'
-                    style={{
-                        height: '100%',
-                        clipPath: 'ellipse(70% 90% at 50% 100%)',
-                    }}>
-                    <div className='flex flex-col mt-[100px]'>
-                        <p className='text-[18px] md:text-[28px]'>
+                    <div className='flex flex-col lg:mt-[150px] mt-[120px] items-center '>
+                        <p className='text-[18px] md:text-[28px] text-center'>
                             En studentorganisasjon med lidenskap for entreprenørskap
                             og bærekraftig utvikling
                         </p>
                         <Button text='LES MER OM OSS' link='/om-oss' />
                     </div>
-                </div>
             </div>
         </div>
     );

--- a/components/frontPage/frontPage.tsx
+++ b/components/frontPage/frontPage.tsx
@@ -1,23 +1,16 @@
 import Logo from '@/components/UI/logo';
 import Button from '@/components/Button/button';
+import Frontprop from './frontProp';
 
-export default function FrontPage() {
+interface FrontPageProps {
+    path: string;
+    alt?: string;
+}
+
+export default function FrontPage( {path, alt} : FrontPageProps) {
     return (
-        <div
-            className='flex flex-col items-center bg-cover bg-center relative'
-            style={{
-                backgroundImage: `url('/images/start_casebreaker.png')`,
-                height: '100vh',
-            }}>
-            <div className='flex flex-col items-center justify-center pt-40 md:pt-60 px-10'>
-                <h2 className='font-bold text-[32px] md:text-[52px] text-center'>
-                    VELKOMMEN TIL
-                </h2>
-                <div className='flex justify-center md:mb-8'>
-                    <Logo />
-                </div>
-            </div>
-
+        <div className='relative'>
+            <Frontprop path={path} title='VELKOMEN TIL' alt={alt} logo={true} />
             <div
                 className='w-full absolute bottom-0'
                 style={{
@@ -31,12 +24,12 @@ export default function FrontPage() {
                     }}></div>
 
                 <div
-                    className='bg-[#132D4E] text-center w-full flex flex-col justify-end items-center relative overflow-hidden'
+                    className='bg-[#132D4E] text-center w-full flex flex-col justify-center items-center relative overflow-hidden'
                     style={{
                         height: '100%',
                         clipPath: 'ellipse(70% 90% at 50% 100%)',
                     }}>
-                    <div className='flex flex-col items-center justify-center pb-8 md:pb-26 md:mb-8 lg:pb-28'>
+                    <div className='flex flex-col mt-[100px]'>
                         <p className='text-[18px] md:text-[28px]'>
                             En studentorganisasjon med lidenskap for entreprenørskap
                             og bærekraftig utvikling

--- a/components/frontPage/frontPage.tsx
+++ b/components/frontPage/frontPage.tsx
@@ -11,7 +11,7 @@ export default function FrontPage() {
                 style={{
                     height: '35%',
                 }}>
-                    <div className='flex flex-col lg:mt-[150px] mt-[120px] items-center '>
+                    <div className='flex flex-col lg:mt-[150px] mt-[110px] items-center '>
                         <p className='text-[18px] md:text-[28px] text-center'>
                             En studentorganisasjon med lidenskap for entreprenørskap
                             og bærekraftig utvikling

--- a/components/frontPage/frontProp.tsx
+++ b/components/frontPage/frontProp.tsx
@@ -3,29 +3,50 @@ import Logo from '@/components/UI/logo';
 interface FrontPageProps { 
     path: string;
     title: string; 
-    alt?: string;
+    color: string;
     logo?: boolean;
 }
 
-export default function Frontprop({ path, alt, logo, title} : FrontPageProps) {
+export default function Frontprop({ path, logo, title, color} : FrontPageProps) {
     return (
         <>
             <div
-            className='flex flex-col items-center bg-cover bg-center relative sm:h-[140vh] h-[100vh]'
+            className='flex flex-col items-center bg-cover bg-center relative sm:h-[140vh] h-[120vh]'
             style={{
                 backgroundImage: `url('${path}')`,
                
             }}>
 
-            <div className='flex flex-col items-center justify-center pt-40 md:pt-60 px-10'>
-                <h2 className='font-bold text-[32px] md:text-[52px] text-center'>
-                    {title}
-                </h2>
-                <div className='flex justify-center md:mb-8'>
-                    {logo && <Logo />}
+                <div className='flex flex-col items-center justify-center pt-40 md:pt-60 px-10'>
+                    <h2 className='font-bold text-[32px] md:text-[52px] text-center'>
+                        {title}
+                    </h2>
+                    <div className='flex justify-center md:mb-8'>
+                        {logo && <Logo />}
+                    </div>
                 </div>
-            </div>
+                <div
+                    className='w-full absolute bottom-0'
+                    style={{
+                        height: '35%',
+                    }}>
+                    <div
+                        className='text-center w-full absolute overflow-hidden opacity-50'
+                        style={{
+                            backgroundColor: color,
+                            height: '100%',
+                            clipPath: 'ellipse(70% 100% at 50% 100%)',
+                        }}></div>
 
+                    <div
+                        className='text-center w-full flex flex-col justify-center items-center relative overflow-hidden'
+                        style={{
+                            backgroundColor: color,
+                            height: '100%',
+                            clipPath: 'ellipse(70% 90% at 50% 100%)',
+                        }}>
+                    </div>
+                </div>
             </div>
         </>
     );

--- a/components/frontPage/frontProp.tsx
+++ b/components/frontPage/frontProp.tsx
@@ -1,5 +1,5 @@
 import Logo from '@/components/UI/logo';
-
+import Image from 'next/image';
 interface FrontPageProps { 
     path: string;
     title: string; 
@@ -10,13 +10,8 @@ interface FrontPageProps {
 export default function Frontprop({ path, logo, title, color} : FrontPageProps) {
     return (
         <>
-            <div
-            className='flex flex-col items-center bg-cover bg-center relative sm:h-[140vh] h-[120vh]'
-            style={{
-                backgroundImage: `url('${path}')`,
-               
-            }}>
-
+            <div className='flex flex-col items-center bg-cover bg-center relative sm:h-[140vh] h-[120vh]'>
+                <Image src={path} alt='' className='blur-sm' fill />
                 <div className='flex flex-col items-center justify-center pt-40 md:pt-60 px-10'>
                     <h2 className='font-bold text-[32px] md:text-[52px] text-center'>
                         {title}

--- a/components/frontPage/frontProp.tsx
+++ b/components/frontPage/frontProp.tsx
@@ -1,0 +1,32 @@
+import Logo from '@/components/UI/logo';
+
+interface FrontPageProps { 
+    path: string;
+    title: string; 
+    alt?: string;
+    logo?: boolean;
+}
+
+export default function Frontprop({ path, alt, logo, title} : FrontPageProps) {
+    return (
+        <>
+            <div
+            className='flex flex-col items-center bg-cover bg-center relative sm:h-[140vh] h-[100vh]'
+            style={{
+                backgroundImage: `url('${path}')`,
+               
+            }}>
+
+            <div className='flex flex-col items-center justify-center pt-40 md:pt-60 px-10'>
+                <h2 className='font-bold text-[32px] md:text-[52px] text-center'>
+                    {title}
+                </h2>
+                <div className='flex justify-center md:mb-8'>
+                    {logo && <Logo />}
+                </div>
+            </div>
+
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
### What has changed? ✨
* Added frontprop component which takes props which are an image, title and color (optional logo). 
* Fixed text clipping on the front page
* Mobile support

## Old:
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/a00f57ec-880f-4969-af80-b72e36003517)
## New:
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/9640c9f1-3eea-41af-afd8-7bda8debca32)

### How did you solve/implement it? 🧠
* Just made a generic front component which has the elipse added. 
* If you want to have text over the elipse you should checkout the frontpage component. 