### PR TITLE
Image txt size fix

### DIFF
--- a/components/imageTextConatiner.tsx
+++ b/components/imageTextConatiner.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 
 interface imageTextContainerProps {
     title?: string;
@@ -19,25 +18,35 @@ export default function ImageTextContainer({
     backgroundColor,
     isImageLeft = true,
 }: imageTextContainerProps) {
-    const currentPath = usePathname();
 
     return (
         <div
             className={`flex flex-col ${
                 isImageLeft ? 'md:flex-row-reverse' : 'md:flex-row'
             } min-w-[375px] py-14 px-5 items-center gap-5 md:gap-10 justify-center ${backgroundColor}`}>
-            <Link
-                href={linkUrl || currentPath}
-                target={linkUrl ? '_blank' : '_self'}
-                rel='noopener noreferrer'>
+            {
+                linkUrl ? (
+                <Link
+                    href={linkUrl}
+                    target={linkUrl ? '_blank' : '_self'}
+                    rel='noopener noreferrer'>
+                    <Image
+                        src={imageSrc}
+                        width={400}
+                        height={400}
+                        alt={`${title || 'bildetekst'}`}
+                        className={`rounded-xl ${linkUrl ? 'hover:opacity-80' : ''}`}
+                    />
+                </Link>
+                ): (
                 <Image
                     src={imageSrc}
                     width={400}
                     height={400}
                     alt={`${title || 'bildetekst'}`}
-                    className={`rounded-xl ${linkUrl ? 'hover:opacity-80' : ''}`}
+                    className={`rounded-xl`}
                 />
-            </Link>
+            )}
             <div
                 className={`px-2 text-${
                     backgroundColor == 'bg-bg-primary' ? 'black' : 'white'

--- a/components/imageTextConatiner.tsx
+++ b/components/imageTextConatiner.tsx
@@ -24,29 +24,31 @@ export default function ImageTextContainer({
             className={`flex flex-col ${
                 isImageLeft ? 'md:flex-row-reverse' : 'md:flex-row'
             } min-w-[375px] py-14 px-5 items-center gap-5 md:gap-10 justify-center ${backgroundColor}`}>
+            <div className='w-[300px] h-[300px] relative'>
             {
                 linkUrl ? (
                 <Link
                     href={linkUrl}
-                    target={linkUrl ? '_blank' : '_self'}
+                    target={linkUrl}
                     rel='noopener noreferrer'>
                     <Image
                         src={imageSrc}
-                        width={400}
-                        height={400}
+                        layout='fill'
+                        objectFit='cover'
                         alt={`${title || 'bildetekst'}`}
-                        className={`rounded-xl ${linkUrl ? 'hover:opacity-80' : ''}`}
+                        className={`rounded-xl hover:opacity-80`}
                     />
                 </Link>
                 ): (
                 <Image
                     src={imageSrc}
-                    width={400}
-                    height={400}
+                    layout='fill'
+                    objectFit='cover'
                     alt={`${title || 'bildetekst'}`}
                     className={`rounded-xl`}
                 />
             )}
+            </div>
             <div
                 className={`px-2 text-${
                     backgroundColor == 'bg-bg-primary' ? 'black' : 'white'


### PR DESCRIPTION
### What has changed? ✨
Fixed a universial size for the images in the imagetextContainer component. Also made the image non clickable when no url is given as argument. 

### before:
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/6c729b25-f0ac-47b8-b340-71740cf81200)
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/4a34f4f2-ca98-4523-9256-2a3ae06fe99c)

### after:
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/35647a70-8249-4187-a2d4-3a4bd01e4d38)
![image](https://github.com/IT-Start-Gjovik/startgjovik_website/assets/133913649/635e5ffd-e61e-4efc-8a34-306269f0e661)


### How did you solve/implement it? 🧠
I used a div for sizing rather then the Image component itself with fill and objectfit to fix size and aspect ratio.